### PR TITLE
updates for intstall-dart-sdk.sh

### DIFF
--- a/shell/install-dart-sdk.sh
+++ b/shell/install-dart-sdk.sh
@@ -3,9 +3,6 @@
 OS=$(/bin/bash /vagrant/shell/os-detect.sh ID)
 CODENAME=$(/bin/bash /vagrant/shell/os-detect.sh CODENAME)
 
-# Get su permission
-sudo su
-
 cd /tmp
 echo "Downloading the SDK, x64"
 
@@ -17,8 +14,14 @@ wget http://storage.googleapis.com/dart-archive/channels/stable/release/latest/s
 
 echo "Downloading done."
 
+# remove the currently install version of the dart sdk
+rm -r /usr/local/bin/dart-sdk
+
 echo "Unzipping to /usr/local/bin"
 unzip dartsdk-linux-x64-release.zip -d /usr/local/bin
+
+# for some reason permissions default to 700
+chmod -R 755 /usr/local/bin/dart-sdk/
 
 echo "Cleaning up"
 rm dartsdk-linux-x64-release.zip
@@ -51,15 +54,37 @@ elif [[ "$OS" == 'centos' ]]; then
 
 fi
 
-echo "DARK_SDK env var set as ${DARK_SDK}"
+echo "DART_SDK env var set as ${DART_SDK}"
 echo "SDK's bin subfolder added to PATH. PATH is now: ${PATH}"
 
 cd /vagrant
-mkdir sample_apps
-cd sample_apps
-git clone https://github.com/Swader/dart_sample_01 sample_01
-git clone https://github.com/Swader/dart_sample_02 sample_02
-git clone https://github.com/Swader/dart_sample_03 sample_03
+if [[ ! -d /vagrant/sample_apps ]]; then
+    mkdir /vagrant/sample_apps
+fi
+
+cd /vagrant/sample_apps
+if [[ ! -d /vagrant/sample_apps/sample_01 ]]; then
+    git clone https://github.com/Swader/dart_sample_01 sample_01
+else
+    cd /vagrant/sample_apps/sample_01
+    git pull
+fi
+
+cd /vagrant/sample_apps
+if [[ ! -d /vagrant/sample_apps/sample_02 ]]; then
+    git clone https://github.com/Swader/dart_sample_02 sample_02
+else
+    cd /vagrant/sample_apps/sample_02
+    git pull
+fi
+
+cd /vagrant/sample_apps
+if [[ ! -d /vagrant/sample_apps/sample_03 ]]; then
+    git clone https://github.com/Swader/dart_sample_02 sample_03
+else
+    cd /vagrant/sample_apps/sample_03
+    git pull
+fi
 
 cmd="/vagrant/shell/dartsync.sh"
 job="*/1 * * * * $cmd"
@@ -67,3 +92,6 @@ echo "$job" > tempcron
 crontab tempcron
 rm tempcron
 #cat <(fgrep -i -v "$cmd" <(crontab -l)) <(echo "$job") | crontab -
+
+# verify dart is working correctly
+/usr/local/bin/dart-sdk/bin/dart --version


### PR DESCRIPTION
@Swader when running the script it didn't seem to allow me to vagrant ssh and execute `dart --version`. I discovered there seemed to be a permissions issue with the unzipped directory. I also made some updates so the script is a bit more idempotent.

thanks,
@iamcharliegoddard
